### PR TITLE
Loglogistic distribution, tests for all, bug fix

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,7 +9,7 @@ iregnet_compute_gradients <- function(X, y, eta, scale, family) {
     .Call('iregnet_iregnet_compute_gradients', PACKAGE = 'iregnet', X, y, eta, scale, family)
 }
 
-fit_cpp <- function(X, y, family, lambda_path, out_status, intercept, alpha, scale_init, estimate_scale, unreg_sol, flag_standardize_x, max_iter, threshold, num_lambda, eps_lambda) {
-    .Call('iregnet_fit_cpp', PACKAGE = 'iregnet', X, y, family, lambda_path, out_status, intercept, alpha, scale_init, estimate_scale, unreg_sol, flag_standardize_x, max_iter, threshold, num_lambda, eps_lambda)
+fit_cpp <- function(X, y, family, lambda_path, debug, out_status, intercept, alpha, scale_init, estimate_scale, unreg_sol, flag_standardize_x, max_iter, threshold, num_lambda, eps_lambda) {
+    .Call('iregnet_fit_cpp', PACKAGE = 'iregnet', X, y, family, lambda_path, debug, out_status, intercept, alpha, scale_init, estimate_scale, unreg_sol, flag_standardize_x, max_iter, threshold, num_lambda, eps_lambda)
 }
 

--- a/R/iregnet.R
+++ b/R/iregnet.R
@@ -4,9 +4,9 @@
 # Borrowed parts from survival survreg and glmnet
 
 iregnet <- function(x, y,
-                    family=c("gaussian", "logistic", "loggaussian", "extreme_value", "exponential"), alpha=1,
+                    family=c("gaussian", "logistic", "loggaussian", "loglogistic", "extreme_value", "exponential"), alpha=1,
                     lambda=double(0), num_lambda=100, intercept=T, standardize=F, scale_init=NA, estimate_scale=T,
-                    maxiter=1000, threshold=1e-4, unreg_sol=T, eps_lambda=NA) {
+                    maxiter=1000, threshold=1e-4, unreg_sol=T, eps_lambda=NA, debug=F) {
 
   # Parameter validation ===============================================
   stopifnot_error("alpha should be between 0 and 1", 0 <= alpha, alpha <= 1)
@@ -47,7 +47,7 @@ iregnet <- function(x, y,
   fit <- fit_cpp(x, y, family, alpha, lambda_path=lambda, num_lambda=num_lambda, intercept=intercept,
                  out_status=status, scale_init=scale_init, max_iter=maxiter, threshold=threshold,
                  flag_standardize_x=standardize, estimate_scale=estimate_scale, unreg_sol=unreg_sol,
-                 eps_lambda=eps_lambda);
+                 eps_lambda=eps_lambda, debug=debug);
 
   fit$call <- match.call()
   fit

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -34,8 +34,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // fit_cpp
-Rcpp::List fit_cpp(Rcpp::NumericMatrix X, Rcpp::NumericMatrix y, Rcpp::String family, Rcpp::NumericVector lambda_path, Rcpp::IntegerVector out_status, bool intercept, double alpha, double scale_init, bool estimate_scale, bool unreg_sol, bool flag_standardize_x, double max_iter, double threshold, int num_lambda, double eps_lambda);
-RcppExport SEXP iregnet_fit_cpp(SEXP XSEXP, SEXP ySEXP, SEXP familySEXP, SEXP lambda_pathSEXP, SEXP out_statusSEXP, SEXP interceptSEXP, SEXP alphaSEXP, SEXP scale_initSEXP, SEXP estimate_scaleSEXP, SEXP unreg_solSEXP, SEXP flag_standardize_xSEXP, SEXP max_iterSEXP, SEXP thresholdSEXP, SEXP num_lambdaSEXP, SEXP eps_lambdaSEXP) {
+Rcpp::List fit_cpp(Rcpp::NumericMatrix X, Rcpp::NumericMatrix y, Rcpp::String family, Rcpp::NumericVector lambda_path, bool debug, Rcpp::IntegerVector out_status, bool intercept, double alpha, double scale_init, bool estimate_scale, bool unreg_sol, bool flag_standardize_x, double max_iter, double threshold, int num_lambda, double eps_lambda);
+RcppExport SEXP iregnet_fit_cpp(SEXP XSEXP, SEXP ySEXP, SEXP familySEXP, SEXP lambda_pathSEXP, SEXP debugSEXP, SEXP out_statusSEXP, SEXP interceptSEXP, SEXP alphaSEXP, SEXP scale_initSEXP, SEXP estimate_scaleSEXP, SEXP unreg_solSEXP, SEXP flag_standardize_xSEXP, SEXP max_iterSEXP, SEXP thresholdSEXP, SEXP num_lambdaSEXP, SEXP eps_lambdaSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
@@ -43,6 +43,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type y(ySEXP);
     Rcpp::traits::input_parameter< Rcpp::String >::type family(familySEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type lambda_path(lambda_pathSEXP);
+    Rcpp::traits::input_parameter< bool >::type debug(debugSEXP);
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type out_status(out_statusSEXP);
     Rcpp::traits::input_parameter< bool >::type intercept(interceptSEXP);
     Rcpp::traits::input_parameter< double >::type alpha(alphaSEXP);
@@ -54,7 +55,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type threshold(thresholdSEXP);
     Rcpp::traits::input_parameter< int >::type num_lambda(num_lambdaSEXP);
     Rcpp::traits::input_parameter< double >::type eps_lambda(eps_lambdaSEXP);
-    __result = Rcpp::wrap(fit_cpp(X, y, family, lambda_path, out_status, intercept, alpha, scale_init, estimate_scale, unreg_sol, flag_standardize_x, max_iter, threshold, num_lambda, eps_lambda));
+    __result = Rcpp::wrap(fit_cpp(X, y, family, lambda_path, debug, out_status, intercept, alpha, scale_init, estimate_scale, unreg_sol, flag_standardize_x, max_iter, threshold, num_lambda, eps_lambda));
     return __result;
 END_RCPP
 }

--- a/src/iregnet.h
+++ b/src/iregnet.h
@@ -10,6 +10,7 @@ typedef enum {
   IREG_DIST_LOGISTIC,
   IREG_DIST_EXTREME_VALUE,
   IREG_DIST_LOG_GAUSSIAN,
+  IREG_DIST_LOG_LOGISTIC,
   IREG_DIST_EXPONENTIAL,
   IREG_DIST_UNKNOWN
 } IREG_DIST;
@@ -30,6 +31,6 @@ IREG_DIST get_ireg_dist (Rcpp::String dist_str);
 double
 compute_grad_response(double *w, double *z, double *scale_update, const double *y_l, const double *y_r,
                       const double *eta, const double scale, const IREG_CENSORING *censoring_type,
-                      const ull n_obs, IREG_DIST dist, double *mu);
+                      const ull n_obs, IREG_DIST dist, double *mu, bool debug);
 
 void get_censoring_types (Rcpp::NumericMatrix &y, IREG_CENSORING *status);


### PR DESCRIPTION
Added log-logistic distribution.

Fixed bug in calculation of the response because of ddg = 0 when the y values
are very small. Now, it returns eta[i] if ddg[i]==0.

Compacted the tests using random data to functions, and added tests for
(log) logistic, gaussian.

Also adds a debug flag to allow printing from inside the fit functions when set true.

Fixes #18 
