### PR TITLE
convergence and standardization tests fail

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iregnet
 Type: Package
 Title: Regularized interval regression
-Version: 2016.09.26
+Version: 2016.11.02
 Author: Anuj Khare <khareanuj18@gmail.com>, Toby D Hocking <toby.hocking@r-project.org>,
     Jelle Goeman
 Maintainer: Anuj Khare <khareanuj18@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: iregnet
 Type: Package
 Title: Regularized interval regression
 Version: 2016.09.26
-Author: Anuj Khare <khareanuj18@gmail.com>, Toby D Hocking <tdhock5@gmail.com>,
+Author: Anuj Khare <khareanuj18@gmail.com>, Toby D Hocking <toby.hocking@r-project.org>,
     Jelle Goeman
 Maintainer: Anuj Khare <khareanuj18@gmail.com>
 Description: Interval regression with four types of censoring and elastic net regularization.

--- a/NEWS
+++ b/NEWS
@@ -2,9 +2,13 @@ TODOs
 
 vignette with speed/accuracy comparisons (fista, glmnet).
 
-2016.11.xx
+sub-differential or duality gap stopping criteria (instead of absolute
+change in variables)
 
-Convergence on penalty.learning data set?
+2016.11.02
+
+Convergence on penalty.learning data set OK with unreg_sol=FALSE and
+increased iterations.
 
 Bugfix for standardization (was not centering before scaling) and
 lambda grid computation (sometimes was not strictly decreasing).

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,18 @@
+TODOs
+
+vignette with speed/accuracy comparisons (fista, glmnet).
+
+2016.11.xx
+
+Convergence on penalty.learning data set?
+
+Bugfix for standardization (was not centering before scaling) and
+lambda grid computation (sometimes was not strictly decreasing).
+
+2016.10.27
+
+plot.iregnet returns a ggplot object.
+
 2016.09.26
 
 TDH added penalty.learning data set and tests.

--- a/R/iregnet.R
+++ b/R/iregnet.R
@@ -135,12 +135,12 @@
 #' fit2 <- iregnet(X, y)
 #'
 #' # Log-Gaussian is same as Gaussian with log-transformed data
-#' set.seed(10)
-#' X <- matrix(rnorm(50), 10, 5)
-#' y <- matrix(abs(rnorm(20)), 10, 2)
-#' y <- t(apply(y, 1, sort)) # intervals must be non-decreasing
-#' fit3 <- iregnet(X, log(y), "gaussian")
-#' fit4 <- iregnet(X, y, "loggaussian")
+#' data("ovarian")
+#' X <- cbind(ovarian$ecog.ps, ovarian$rx)
+#' y <- Surv(ovarian$futime, ovarian$fustat)
+#' y_log <- Surv(log(ovarian$futime), ovarian$fustat)
+#' fit3 <- iregnet(X, y_log, "gaussian", threshold=1e-2)
+#' fit4 <- iregnet(X, y, "loggaussian", threshold=1e-2)
 #'
 #' # Scale parameter can be fixed by setting the estimate_scale flag.
 #' set.seed(10)

--- a/man/iregnet.Rd
+++ b/man/iregnet.Rd
@@ -144,12 +144,12 @@ y <- Surv(ovarian$futime, ovarian$fustat)
 fit2 <- iregnet(X, y)
 
 # Log-Gaussian is same as Gaussian with log-transformed data
-set.seed(10)
-X <- matrix(rnorm(50), 10, 5)
-y <- matrix(abs(rnorm(20)), 10, 2)
-y <- t(apply(y, 1, sort)) # intervals must be non-decreasing
-fit3 <- iregnet(X, log(y), "gaussian")
-fit4 <- iregnet(X, y, "loggaussian")
+data("ovarian")
+X <- cbind(ovarian$ecog.ps, ovarian$rx)
+y <- Surv(ovarian$futime, ovarian$fustat)
+y_log <- Surv(log(ovarian$futime), ovarian$fustat)
+fit3 <- iregnet(X, y_log, "gaussian", threshold=1e-2)
+fit4 <- iregnet(X, y, "loggaussian", threshold=1e-2)
 
 # Scale parameter can be fixed by setting the estimate_scale flag.
 set.seed(10)

--- a/src/iregnet_fit.cpp
+++ b/src/iregnet_fit.cpp
@@ -330,9 +330,12 @@ fit_cpp(Rcpp::NumericMatrix X, Rcpp::NumericMatrix y,
       out_beta(0, m) += mean_y;     // intercept will contain the contribution of mean_y
 
     if (flag_standardize_x) {
+      double intercept_diff = 0;
       for (ull i = int(intercept); i < n_vars; ++i) {  // no standardization for intercept
         out_beta(i, m) = out_beta(i, m) / std_x[i];
+        intercept_diff += out_beta(i, m) * mean_x[i];
       }
+      out_beta(0, m) -= intercept_diff;
     }
   }
 
@@ -462,8 +465,8 @@ standardize_x (Rcpp::NumericMatrix &X,
     mean_x[i] /= X.nrow();
 
     for (ull j = 0; j < X.nrow(); ++j) {
-      temp = X(j, i) - mean_x[i];
-      std_x[i] += temp * temp;
+      X(j, i) = X(j, i) - mean_x[i];  // center X
+      std_x[i] += X(j, i) * X(j, i);
     }
 
     // not using (N-1) in denominator to agree with glmnet

--- a/src/iregnet_fit.cpp
+++ b/src/iregnet_fit.cpp
@@ -121,8 +121,8 @@ fit_cpp(Rcpp::NumericMatrix X, Rcpp::NumericMatrix y,
   if (lambda_path.size() > 0) {
     for(ull i = 0; i < num_lambda; ++i) {
       // Make sure that the given lambda_path is non-negative decreasing
-      if (lambda_path[i] < 0) {
-        Rcpp::stop("lambdas must be positive.");
+      if (lambda_path[i] < 0 || (i > 0 && lambda_path[i] > lambda_path[i-1])) {
+        Rcpp::stop("lambdas must be positive and decreasing.");
       }
 
       out_lambda[i] = lambda_path[i];
@@ -220,8 +220,6 @@ fit_cpp(Rcpp::NumericMatrix X, Rcpp::NumericMatrix y,
       /* Calculate lambda_max using intial scale fit */
       if (m == 1) {
         lambda_seq[m] = compute_lambda_max(X, w, z, eta, intercept, alpha, n_vars, n_obs, debug);
-        lambda_max_unscaled = lambda_seq[m] * scale * scale;
-        // lambda_max_unscaled = lambda_seq[m] = lambda_seq[m] * scale * scale;
 
       /* Last solution should be unregularized if the flag is set */
       } else if (m == num_lambda && unreg_sol == true)
@@ -229,8 +227,7 @@ fit_cpp(Rcpp::NumericMatrix X, Rcpp::NumericMatrix y,
 
       /* All other lambda calculated */
       else if (m > 1) {
-        // lambda_seq[m] = lambda_seq[m - 1] * eps_ratio;
-        lambda_seq[m] = lambda_max_unscaled * pow(eps_ratio, m-1) / scale / scale;
+        lambda_seq[m] = lambda_seq[m - 1] * eps_ratio;
       }
     }
 
@@ -296,10 +293,6 @@ fit_cpp(Rcpp::NumericMatrix X, Rcpp::NumericMatrix y,
 
       if (estimate_scale) {
         log_scale += scale_update; scale = exp(log_scale);
-        // scale the lambda value according to current scale unless you are at unregularized sol
-        // done to match values with Glment for Gaussian, no censoring
-        if ((m != num_lambda || unreg_sol == false) && lambda_path.size() == 0 && m > 1)
-          lambda_seq[m] = lambda_max_unscaled * pow(eps_ratio, m-1) / scale / scale;    // FIXME: Scale! :O
 
         // if (fabs(scale - old_scale) > threshold) {    // TODO: Maybe should be different for sigma?
         if (fabs(scale - old_scale) > 1e-4) {    // TODO: Maybe should be different for sigma?

--- a/src/iregnet_fit.cpp
+++ b/src/iregnet_fit.cpp
@@ -455,8 +455,6 @@ standardize_x (Rcpp::NumericMatrix &X,
                double *mean_x, double *std_x,
                bool intercept)
 {
-  double temp;
-
   for (ull i = int(intercept); i < X.ncol(); ++i) {  // don't standardize intercept col.
     mean_x[i] = std_x[i] = 0;
     for (ull j = 0; j < X.nrow(); ++j) {

--- a/src/iregnet_fit.cpp
+++ b/src/iregnet_fit.cpp
@@ -1,3 +1,5 @@
+/* for easy compilation in emacs -*- compile-command: "R CMD INSTALL .." -*- */
+
 /*
  * iregnet_fit.cpp
  * Author: Anuj Khare <khareanuj18@gmail.com>
@@ -247,6 +249,8 @@ fit_cpp(Rcpp::NumericMatrix X, Rcpp::NumericMatrix y,
     n_iters[m] = 0;
     do {                                  // until Convergence of beta
 
+      n_iters[m]++;
+
       flag_beta_converged = 1;            // = 1 if beta converges
       old_scale = scale;
 
@@ -277,7 +281,9 @@ fit_cpp(Rcpp::NumericMatrix X, Rcpp::NumericMatrix y,
         }
 
         // if any beta_k has not converged, we will come back for another cycle.
-        if (fabs(beta_new - beta[k]) > threshold) {
+	double abs_change = fabs(beta_new - beta[k]);
+        if (abs_change > threshold) {
+	  if(debug==1 && max_iter==n_iters[m])printf("iter=%d lambda=%d beta_%lld not converged, abs_change=%f > %f=threshold\n", n_iters[m], m, k, abs_change, threshold);
           flag_beta_converged = 0;
           beta[k] = beta_new;
         }
@@ -302,12 +308,12 @@ fit_cpp(Rcpp::NumericMatrix X, Rcpp::NumericMatrix y,
           lambda_seq[m] = lambda_max_unscaled * pow(eps_ratio, m-1) / scale / scale;    // FIXME: Scale! :O
 
         // if (fabs(scale - old_scale) > threshold) {    // TODO: Maybe should be different for sigma?
-        if (fabs(scale - old_scale) > 1e-4) {    // TODO: Maybe should be different for sigma?
+	double abs_change = fabs(scale - old_scale);
+        if (abs_change > threshold) {    // TODO: Maybe should be different for sigma?
+	  if(debug==1 && max_iter==n_iters[m])printf("iter=%d lambda=%d scale not converged, abs_change=%f > %f=threshold\n", n_iters[m], m, abs_change, threshold);
           flag_beta_converged = 0;
         }
       }
-
-      n_iters[m]++;
     } while ((flag_beta_converged != 1) && (n_iters[m] < max_iter));
 
     out_loglik[m] = loglik;

--- a/tests/testthat/test_penaltyLearning.R
+++ b/tests/testthat/test_penaltyLearning.R
@@ -14,9 +14,191 @@ X.train <- penalty.learning$X.mat[sets$train,]
 y.train <- penalty.learning$y.mat[sets$train,]
 fit <- iregnet(
   X.train, y.train,
-  ##threshold=1e-1,
+  unreg_sol=FALSE,
   standardize=TRUE,
-  debug=1)
+  debug=1,
+  maxiter=1e5)
+
+if(FALSE){
+  conv.txt <- "
+iter=1000 lambda=68 beta_19 not converged, abs_change=0.000319 > 0.000100=threshold
+iter=1000 lambda=68 beta_22 not converged, abs_change=0.000334 > 0.000100=threshold
+iter=1000 lambda=69 beta_19 not converged, abs_change=0.000524 > 0.000100=threshold
+iter=1000 lambda=69 beta_22 not converged, abs_change=0.000548 > 0.000100=threshold
+iter=1000 lambda=70 beta_19 not converged, abs_change=0.000705 > 0.000100=threshold
+iter=1000 lambda=70 beta_22 not converged, abs_change=0.000735 > 0.000100=threshold
+iter=1000 lambda=85 beta_9 not converged, abs_change=0.000231 > 0.000100=threshold
+iter=1000 lambda=85 beta_22 not converged, abs_change=0.000324 > 0.000100=threshold
+iter=1000 lambda=86 beta_3 not converged, abs_change=0.000659 > 0.000100=threshold
+iter=1000 lambda=86 beta_8 not converged, abs_change=0.000476 > 0.000100=threshold
+iter=1000 lambda=86 beta_9 not converged, abs_change=0.000264 > 0.000100=threshold
+iter=1000 lambda=86 beta_11 not converged, abs_change=0.000102 > 0.000100=threshold
+iter=1000 lambda=86 beta_13 not converged, abs_change=0.000119 > 0.000100=threshold
+iter=1000 lambda=86 beta_18 not converged, abs_change=0.000133 > 0.000100=threshold
+iter=1000 lambda=86 beta_22 not converged, abs_change=0.000363 > 0.000100=threshold
+iter=1000 lambda=87 beta_3 not converged, abs_change=0.000146 > 0.000100=threshold
+iter=1000 lambda=87 beta_8 not converged, abs_change=0.000173 > 0.000100=threshold
+iter=1000 lambda=87 beta_9 not converged, abs_change=0.000240 > 0.000100=threshold
+iter=1000 lambda=87 beta_22 not converged, abs_change=0.000342 > 0.000100=threshold
+iter=1000 lambda=88 beta_0 not converged, abs_change=0.000149 > 0.000100=threshold
+iter=1000 lambda=88 beta_1 not converged, abs_change=0.000666 > 0.000100=threshold
+iter=1000 lambda=88 beta_3 not converged, abs_change=0.000838 > 0.000100=threshold
+iter=1000 lambda=88 beta_8 not converged, abs_change=0.000294 > 0.000100=threshold
+iter=1000 lambda=88 beta_9 not converged, abs_change=0.000192 > 0.000100=threshold
+iter=1000 lambda=88 beta_11 not converged, abs_change=0.000388 > 0.000100=threshold
+iter=1000 lambda=88 beta_13 not converged, abs_change=0.000286 > 0.000100=threshold
+iter=1000 lambda=88 beta_14 not converged, abs_change=0.000106 > 0.000100=threshold
+iter=1000 lambda=88 beta_18 not converged, abs_change=0.000115 > 0.000100=threshold
+iter=1000 lambda=88 beta_22 not converged, abs_change=0.000299 > 0.000100=threshold
+iter=1000 lambda=89 beta_0 not converged, abs_change=0.000124 > 0.000100=threshold
+iter=1000 lambda=89 beta_1 not converged, abs_change=0.001011 > 0.000100=threshold
+iter=1000 lambda=89 beta_3 not converged, abs_change=0.001495 > 0.000100=threshold
+iter=1000 lambda=89 beta_5 not converged, abs_change=0.000104 > 0.000100=threshold
+iter=1000 lambda=89 beta_8 not converged, abs_change=0.000595 > 0.000100=threshold
+iter=1000 lambda=89 beta_9 not converged, abs_change=0.000161 > 0.000100=threshold
+iter=1000 lambda=89 beta_11 not converged, abs_change=0.000610 > 0.000100=threshold
+iter=1000 lambda=89 beta_13 not converged, abs_change=0.000308 > 0.000100=threshold
+iter=1000 lambda=89 beta_14 not converged, abs_change=0.000158 > 0.000100=threshold
+iter=1000 lambda=89 beta_15 not converged, abs_change=0.000111 > 0.000100=threshold
+iter=1000 lambda=89 beta_18 not converged, abs_change=0.000138 > 0.000100=threshold
+iter=1000 lambda=89 beta_20 not converged, abs_change=0.000246 > 0.000100=threshold
+iter=1000 lambda=89 beta_22 not converged, abs_change=0.000180 > 0.000100=threshold
+iter=1000 lambda=90 beta_0 not converged, abs_change=0.000116 > 0.000100=threshold
+iter=1000 lambda=90 beta_1 not converged, abs_change=0.000875 > 0.000100=threshold
+iter=1000 lambda=90 beta_3 not converged, abs_change=0.001022 > 0.000100=threshold
+iter=1000 lambda=90 beta_4 not converged, abs_change=0.000110 > 0.000100=threshold
+iter=1000 lambda=90 beta_8 not converged, abs_change=0.000281 > 0.000100=threshold
+iter=1000 lambda=90 beta_9 not converged, abs_change=0.000151 > 0.000100=threshold
+iter=1000 lambda=90 beta_11 not converged, abs_change=0.000531 > 0.000100=threshold
+iter=1000 lambda=90 beta_13 not converged, abs_change=0.000217 > 0.000100=threshold
+iter=1000 lambda=90 beta_14 not converged, abs_change=0.000138 > 0.000100=threshold
+iter=1000 lambda=90 beta_15 not converged, abs_change=0.000109 > 0.000100=threshold
+iter=1000 lambda=90 beta_18 not converged, abs_change=0.000119 > 0.000100=threshold
+iter=1000 lambda=90 beta_20 not converged, abs_change=0.000186 > 0.000100=threshold
+iter=1000 lambda=90 beta_22 not converged, abs_change=0.000183 > 0.000100=threshold
+iter=1000 lambda=91 beta_1 not converged, abs_change=0.000423 > 0.000100=threshold
+iter=1000 lambda=91 beta_3 not converged, abs_change=0.000395 > 0.000100=threshold
+iter=1000 lambda=91 beta_4 not converged, abs_change=0.000324 > 0.000100=threshold
+iter=1000 lambda=91 beta_9 not converged, abs_change=0.000138 > 0.000100=threshold
+iter=1000 lambda=91 beta_11 not converged, abs_change=0.000379 > 0.000100=threshold
+iter=1000 lambda=91 beta_14 not converged, abs_change=0.000277 > 0.000100=threshold
+iter=1000 lambda=91 beta_20 not converged, abs_change=0.000190 > 0.000100=threshold
+iter=1000 lambda=91 beta_22 not converged, abs_change=0.000142 > 0.000100=threshold
+iter=1000 lambda=92 beta_3 not converged, abs_change=0.000577 > 0.000100=threshold
+iter=1000 lambda=92 beta_4 not converged, abs_change=0.000194 > 0.000100=threshold
+iter=1000 lambda=92 beta_8 not converged, abs_change=0.000424 > 0.000100=threshold
+iter=1000 lambda=92 beta_9 not converged, abs_change=0.000147 > 0.000100=threshold
+iter=1000 lambda=92 beta_13 not converged, abs_change=0.000118 > 0.000100=threshold
+iter=1000 lambda=92 beta_14 not converged, abs_change=0.000151 > 0.000100=threshold
+iter=1000 lambda=92 beta_18 not converged, abs_change=0.000144 > 0.000100=threshold
+iter=1000 lambda=92 beta_20 not converged, abs_change=0.000128 > 0.000100=threshold
+iter=1000 lambda=92 beta_22 not converged, abs_change=0.000176 > 0.000100=threshold
+iter=1000 lambda=93 beta_1 not converged, abs_change=0.000529 > 0.000100=threshold
+iter=1000 lambda=93 beta_3 not converged, abs_change=0.000795 > 0.000100=threshold
+iter=1000 lambda=93 beta_4 not converged, abs_change=0.000256 > 0.000100=threshold
+iter=1000 lambda=93 beta_8 not converged, abs_change=0.000819 > 0.000100=threshold
+iter=1000 lambda=93 beta_9 not converged, abs_change=0.000175 > 0.000100=threshold
+iter=1000 lambda=93 beta_11 not converged, abs_change=0.000240 > 0.000100=threshold
+iter=1000 lambda=93 beta_13 not converged, abs_change=0.000116 > 0.000100=threshold
+iter=1000 lambda=93 beta_18 not converged, abs_change=0.000179 > 0.000100=threshold
+iter=1000 lambda=93 beta_22 not converged, abs_change=0.000241 > 0.000100=threshold
+iter=1000 lambda=94 beta_1 not converged, abs_change=0.000535 > 0.000100=threshold
+iter=1000 lambda=94 beta_3 not converged, abs_change=0.000725 > 0.000100=threshold
+iter=1000 lambda=94 beta_4 not converged, abs_change=0.000244 > 0.000100=threshold
+iter=1000 lambda=94 beta_8 not converged, abs_change=0.000751 > 0.000100=threshold
+iter=1000 lambda=94 beta_9 not converged, abs_change=0.000181 > 0.000100=threshold
+iter=1000 lambda=94 beta_11 not converged, abs_change=0.000288 > 0.000100=threshold
+iter=1000 lambda=94 beta_13 not converged, abs_change=0.000130 > 0.000100=threshold
+iter=1000 lambda=94 beta_18 not converged, abs_change=0.000148 > 0.000100=threshold
+iter=1000 lambda=94 beta_22 not converged, abs_change=0.000252 > 0.000100=threshold
+iter=1000 lambda=95 beta_1 not converged, abs_change=0.000611 > 0.000100=threshold
+iter=1000 lambda=95 beta_3 not converged, abs_change=0.000681 > 0.000100=threshold
+iter=1000 lambda=95 beta_4 not converged, abs_change=0.000136 > 0.000100=threshold
+iter=1000 lambda=95 beta_8 not converged, abs_change=0.000686 > 0.000100=threshold
+iter=1000 lambda=95 beta_9 not converged, abs_change=0.000185 > 0.000100=threshold
+iter=1000 lambda=95 beta_11 not converged, abs_change=0.000381 > 0.000100=threshold
+iter=1000 lambda=95 beta_13 not converged, abs_change=0.000107 > 0.000100=threshold
+iter=1000 lambda=95 beta_18 not converged, abs_change=0.000114 > 0.000100=threshold
+iter=1000 lambda=95 beta_22 not converged, abs_change=0.000253 > 0.000100=threshold
+iter=1000 lambda=96 beta_1 not converged, abs_change=0.000676 > 0.000100=threshold
+iter=1000 lambda=96 beta_3 not converged, abs_change=0.000696 > 0.000100=threshold
+iter=1000 lambda=96 beta_4 not converged, abs_change=0.000162 > 0.000100=threshold
+iter=1000 lambda=96 beta_8 not converged, abs_change=0.000626 > 0.000100=threshold
+iter=1000 lambda=96 beta_9 not converged, abs_change=0.000185 > 0.000100=threshold
+iter=1000 lambda=96 beta_11 not converged, abs_change=0.000344 > 0.000100=threshold
+iter=1000 lambda=96 beta_13 not converged, abs_change=0.000153 > 0.000100=threshold
+iter=1000 lambda=96 beta_18 not converged, abs_change=0.000143 > 0.000100=threshold
+iter=1000 lambda=96 beta_22 not converged, abs_change=0.000254 > 0.000100=threshold
+iter=1000 lambda=97 beta_0 not converged, abs_change=0.000117 > 0.000100=threshold
+iter=1000 lambda=97 beta_1 not converged, abs_change=0.000512 > 0.000100=threshold
+iter=1000 lambda=97 beta_3 not converged, abs_change=0.000115 > 0.000100=threshold
+iter=1000 lambda=97 beta_4 not converged, abs_change=0.001091 > 0.000100=threshold
+iter=1000 lambda=97 beta_5 not converged, abs_change=0.000210 > 0.000100=threshold
+iter=1000 lambda=97 beta_8 not converged, abs_change=0.000363 > 0.000100=threshold
+iter=1000 lambda=97 beta_9 not converged, abs_change=0.000151 > 0.000100=threshold
+iter=1000 lambda=97 beta_10 not converged, abs_change=0.001366 > 0.000100=threshold
+iter=1000 lambda=97 beta_11 not converged, abs_change=0.000152 > 0.000100=threshold
+iter=1000 lambda=97 beta_14 not converged, abs_change=0.000215 > 0.000100=threshold
+iter=1000 lambda=97 beta_15 not converged, abs_change=0.000115 > 0.000100=threshold
+iter=1000 lambda=97 beta_20 not converged, abs_change=0.000261 > 0.000100=threshold
+iter=1000 lambda=97 beta_22 not converged, abs_change=0.000187 > 0.000100=threshold
+iter=1000 lambda=98 beta_3 not converged, abs_change=0.000278 > 0.000100=threshold
+iter=1000 lambda=98 beta_4 not converged, abs_change=0.002066 > 0.000100=threshold
+iter=1000 lambda=98 beta_5 not converged, abs_change=0.000441 > 0.000100=threshold
+iter=1000 lambda=98 beta_8 not converged, abs_change=0.000251 > 0.000100=threshold
+iter=1000 lambda=98 beta_10 not converged, abs_change=0.002604 > 0.000100=threshold
+iter=1000 lambda=98 beta_12 not converged, abs_change=0.000131 > 0.000100=threshold
+iter=1000 lambda=98 beta_13 not converged, abs_change=0.000174 > 0.000100=threshold
+iter=1000 lambda=98 beta_14 not converged, abs_change=0.000344 > 0.000100=threshold
+iter=1000 lambda=98 beta_15 not converged, abs_change=0.000139 > 0.000100=threshold
+iter=1000 lambda=98 beta_20 not converged, abs_change=0.000442 > 0.000100=threshold
+iter=1000 lambda=99 beta_0 not converged, abs_change=0.000120 > 0.000100=threshold
+iter=1000 lambda=99 beta_1 not converged, abs_change=0.000259 > 0.000100=threshold
+iter=1000 lambda=99 beta_3 not converged, abs_change=0.000232 > 0.000100=threshold
+iter=1000 lambda=99 beta_4 not converged, abs_change=0.002429 > 0.000100=threshold
+iter=1000 lambda=99 beta_5 not converged, abs_change=0.000467 > 0.000100=threshold
+iter=1000 lambda=99 beta_8 not converged, abs_change=0.000385 > 0.000100=threshold
+iter=1000 lambda=99 beta_10 not converged, abs_change=0.003051 > 0.000100=threshold
+iter=1000 lambda=99 beta_13 not converged, abs_change=0.000111 > 0.000100=threshold
+iter=1000 lambda=99 beta_14 not converged, abs_change=0.000417 > 0.000100=threshold
+iter=1000 lambda=99 beta_15 not converged, abs_change=0.000175 > 0.000100=threshold
+iter=1000 lambda=99 beta_20 not converged, abs_change=0.000531 > 0.000100=threshold
+iter=1000 lambda=100 beta_0 not converged, abs_change=0.000189 > 0.000100=threshold
+iter=1000 lambda=100 beta_1 not converged, abs_change=0.009196 > 0.000100=threshold
+iter=1000 lambda=100 beta_2 not converged, abs_change=0.014089 > 0.000100=threshold
+iter=1000 lambda=100 beta_3 not converged, abs_change=0.013880 > 0.000100=threshold
+iter=1000 lambda=100 beta_4 not converged, abs_change=0.021450 > 0.000100=threshold
+iter=1000 lambda=100 beta_5 not converged, abs_change=0.001476 > 0.000100=threshold
+iter=1000 lambda=100 beta_6 not converged, abs_change=0.015418 > 0.000100=threshold
+iter=1000 lambda=100 beta_7 not converged, abs_change=0.004489 > 0.000100=threshold
+iter=1000 lambda=100 beta_8 not converged, abs_change=0.006411 > 0.000100=threshold
+iter=1000 lambda=100 beta_9 not converged, abs_change=0.001652 > 0.000100=threshold
+iter=1000 lambda=100 beta_10 not converged, abs_change=0.020020 > 0.000100=threshold
+iter=1000 lambda=100 beta_11 not converged, abs_change=0.004888 > 0.000100=threshold
+iter=1000 lambda=100 beta_12 not converged, abs_change=0.001375 > 0.000100=threshold
+iter=1000 lambda=100 beta_13 not converged, abs_change=0.000826 > 0.000100=threshold
+iter=1000 lambda=100 beta_14 not converged, abs_change=0.004221 > 0.000100=threshold
+iter=1000 lambda=100 beta_15 not converged, abs_change=0.001205 > 0.000100=threshold
+iter=1000 lambda=100 beta_16 not converged, abs_change=0.011938 > 0.000100=threshold
+iter=1000 lambda=100 beta_17 not converged, abs_change=0.001000 > 0.000100=threshold
+iter=1000 lambda=100 beta_18 not converged, abs_change=0.000239 > 0.000100=threshold
+iter=1000 lambda=100 beta_19 not converged, abs_change=0.001655 > 0.000100=threshold
+iter=1000 lambda=100 beta_20 not converged, abs_change=0.003510 > 0.000100=threshold
+iter=1000 lambda=100 beta_21 not converged, abs_change=0.001055 > 0.000100=threshold
+iter=1000 lambda=100 beta_22 not converged, abs_change=0.000498 > 0.000100=threshold
+"
+  library(namedCapture)
+  pattern <- paste0(
+    "lambda=",
+    "(?<lambda>[0-9]+)",
+    " ",
+    "(?<variable>[^ ]+)",
+    " not converged, abs_change=",
+    "(?<abs_change>[^ ]+)")
+  conv.df <- str_match_all_named(conv.txt, pattern, list(lambda=as.integer, abs_change=as.numeric))[[1]]
+  library(Matrix)
+  Matrix(with(conv.df, table(variable, lambda)))
+}
 
 test_that("predict function same as matrix multiplication when standardize=TRUE", {
   expect_equal(cbind(1, X.train) %*% fit$beta, predict(fit, X.train))
@@ -124,7 +306,10 @@ dimnames(X.scaled) <- dimnames(X.unscaled)
 ufit <- iregnet(
   X.scaled, y.train,
   ## scale_init=1, estimate_scale=FALSE,
-  standardize=FALSE)
+  unreg_sol=FALSE,
+  standardize=FALSE,
+  debug=1,
+  maxiter=1e5)
 pred.mat <- predict(ufit, X.scaled)
 test_that("predict function same as matrix multiplication when standardize=FALSE", {
   expect_equal(cbind(1, X.scaled) %*% ufit$beta, pred.mat)

--- a/tests/testthat/test_penaltyLearning.R
+++ b/tests/testthat/test_penaltyLearning.R
@@ -15,7 +15,8 @@ y.train <- penalty.learning$y.mat[sets$train,]
 fit <- iregnet(
   X.train, y.train,
   ##threshold=1e-1,
-  standardize=TRUE)
+  standardize=TRUE,
+  debug=1)
 
 test_that("predict function same as matrix multiplication when standardize=TRUE", {
   expect_equal(cbind(1, X.train) %*% fit$beta, predict(fit, X.train))

--- a/tests/testthat/test_penaltyLearning.R
+++ b/tests/testthat/test_penaltyLearning.R
@@ -1,11 +1,141 @@
+library(testthat)
+library(iregnet)
 context("\npenalty learning data set")
 
 data(penalty.learning)
 
-fit <- with(penalty.learning, iregnet(X.mat, y.mat))
-l1.norm.vec <- colSums(abs(fit$beta[-1,]))
+chrom.vec <- sub(":.*", "", rownames(penalty.learning$X.mat))
+table(chrom.vec)
+train.chroms <- c("chr1", "chr9")
+sets <-
+  list(train=chrom.vec %in% train.chroms,
+       validation=! chrom.vec %in% train.chroms)
+X.train <- penalty.learning$X.mat[sets$train,]
+y.train <- penalty.learning$y.mat[sets$train,]
+fit <- iregnet(
+  X.train, y.train,
+  standardize=TRUE)
 
+test_that("predict function same as matrix multiplication when standardize=TRUE", {
+  expect_equal(cbind(1, X.train) %*% fit$beta, predict(fit, X.train))
+})
+
+l1.norm.vec <- colSums(abs(fit$beta[-1,]))
 test_that("only one model should have L1 arclength 0", {
   n.zero <- sum(l1.norm.vec == 0)
   expect_equal(n.zero, 1)
 })
+
+pred.loglik <- function(pred.mean, pred.scale, target.mat){
+  stopifnot(identical(ncol(target.mat), 2L))
+  n.obs <- nrow(target.mat)
+  stopifnot(identical(nrow(pred.mean), n.obs))
+  stopifnot(identical(nrow(pred.scale), n.obs))
+  prob.below.left <- pnorm(target.mat[,1], pred.mean, pred.scale)
+  prob.below.right <- pnorm(target.mat[,2], pred.mean, pred.scale)
+  log(prob.below.right-prob.below.left)
+}
+
+set.error.list <- list()
+for(set.name in names(sets)){
+  is.set <- sets[[set.name]]
+  pred.mat <- predict(fit, penalty.learning$X.mat[is.set,])
+  y.set <- penalty.learning$y.mat[is.set,]
+  too.lo <- colSums(pred.mat < y.set[,1])
+  too.hi <- colSums(y.set[,2] < pred.mat)
+  errors <- too.lo + too.hi
+  scale.mat <- matrix(fit$scale, nrow(y.set), length(fit$scale), byrow=TRUE)
+  log.prob <- pred.loglik(pred.mat, scale.mat, y.set)
+  set.error.list[[set.name]] <- data.frame(
+    set.name,
+    lambda=fit$lambda,
+    too.lo,
+    too.hi,
+    errors,
+    iterations=fit$n_iters,
+    surrogate.loss=-colMeans(log.prob),
+    percent.error=100*errors/nrow(y.set))
+}
+set.error <- do.call(rbind, set.error.list)
+train.error <- subset(set.error, set.name=="train")
+
+if(interactive()){
+  library(ggplot2)
+
+  tidy <- tidydf(fit)
+  some <- subset(tidy, variable != "(Intercept)" & arclength < 2)
+
+  ggplot()+
+    geom_path(aes(-log(lambda), weight, color=variable, group=variable),
+              data=some)
+
+  ggplot()+
+    geom_path(aes(arclength, weight, color=variable, group=variable),
+              data=some)+
+    geom_point(aes(arclength, weight, color=variable, group=variable),
+               shape=1,
+               data=subset(some, weight != 0))
+
+  ggplot()+
+    theme_bw()+
+    theme(panel.margin=grid::unit(0, "lines"))+
+    facet_grid(metric ~ ., scales="free")+
+    geom_path(aes(-log(lambda), surrogate.loss, color=set.name, group=set.name),
+              data=data.frame(set.error, metric="surrogate loss"))+
+    geom_path(aes(-log(lambda), iterations),
+              data=data.frame(train.error, metric="iterations"))+
+    geom_path(aes(-log(lambda), percent.error, color=set.name, group=set.name),
+              data=data.frame(set.error, metric="percent incorrect intervals"))
+
+  plot(log(fit$lambda))
+
+}
+
+test_that("train set surrogate loss always decreases", {
+  diff.vec <- diff(train.error$surrogate.loss)
+  expect_true(all(diff.vec < 0))
+})
+
+test_that("error_status is 0", {
+  expect_equal(fit$error_status, 0)
+})
+
+## Another fit with standardize=FALSE.
+X.unscaled <- X.train
+mean.vec <- colMeans(X.unscaled)
+M <- matrix(
+  mean.vec, nrow(X.unscaled), ncol(X.unscaled), byrow=TRUE)
+X.centered <- X.unscaled - M
+sd.vec <- sqrt(colSums(X.centered * X.centered)/nrow(X.centered))
+S <- diag(1/sd.vec)
+X.scaled <- X.centered %*% S
+##X.scaled <- X.unscaled %*% S #UNCOMMENT TO MAKE TESTS BELOW PASS.
+dimnames(X.scaled) <- dimnames(X.unscaled)
+ufit <- iregnet(
+  X.scaled, y.train,
+  ## scale_init=1, estimate_scale=FALSE,
+  standardize=FALSE)
+pred.mat <- predict(ufit, X.scaled)
+test_that("predict function same as matrix multiplication when standardize=FALSE", {
+  expect_equal(cbind(1, X.scaled) %*% ufit$beta, pred.mat)
+})
+## If x is an unscaled p-vector then z = S'(x-m) is a scaled p-vector,
+## where m is a p-vector of means and S is a (p x p) diagonal matrix
+## of 1/sd values. The iregnet(standardize=FALSE) function gives us a
+## p-vector of weights w and an intercept b, so the final prediction
+## function is w'z + b = w'S(x-m) + b = w'Sz + b - w'Sm. Below we
+## compute the scaled.beta.mat which contains the w'S vectors, and the
+## pred.weight.mat which can be used for prediction with unscaled
+## data.
+scaled.beta.mat <- S %*% ufit$beta[-1,]
+intercept.vec <- ufit$beta[1,] - mean.vec %*% scaled.beta.mat
+##intercept.vec <- ufit$beta[1,] #UNCOMMENT TO MAKE TESTS BELOW PASS.
+pred.weight.mat <- rbind(intercept.vec, scaled.beta.mat)
+my.pred.mat <- cbind(1, X.train) %*% pred.weight.mat
+test_that("lambda seq is the same", {
+  expect_equal(fit$lambda, ufit$lambda)
+})
+test_that("learned weights are the same", {
+  expect_equal(unname(pred.weight.mat), unname(fit$beta))
+})
+

--- a/tests/testthat/test_penaltyLearning.R
+++ b/tests/testthat/test_penaltyLearning.R
@@ -77,6 +77,7 @@ if(interactive()){
                data=subset(some, weight != 0))
 
   ggplot()+
+    ggtitle("iregnet on penalty.learning data set")+
     theme_bw()+
     theme(panel.margin=grid::unit(0, "lines"))+
     facet_grid(metric ~ ., scales="free")+

--- a/tests/testthat/test_survival_glmnet.R
+++ b/tests/testthat/test_survival_glmnet.R
@@ -25,12 +25,13 @@ test_that("Gaussian, exact data - coefficients are calculated correctly wrt surv
   for (n_vars in 5:10)
   {
     xy <- get_xy(30, n_vars, "none", standardize=std)
-    xy1 <- xy
 
     fit_s <- survreg(xy$surv ~ xy$x, dist = "gaussian")
     fit_i <- iregnet(xy$x, xy$y, "gaussian", alpha = 1, intercept = T, thresh=1e-4, standardize=T,
     debug=F)
 
+    # Note: fit$lambda returned by iregnet are scaled by (1/scale^2) in the
+    # case of gaussian exact data. Rescale to compare the solutions.
     lambda_path <- fit_i$lambda * (fit_i$scale ** 2)
     fit_g <- glmnet(xy$x, xy$y[, 1], "gaussian", lambda=lambda_path, thresh=1e-7, standardize=T)
 

--- a/tests/testthat/test_validation.R
+++ b/tests/testthat/test_validation.R
@@ -32,8 +32,8 @@ test_that("Fit parameters are validated properly", {
 
   # lambda
   expect_error(iregnet(x, y, lambda='s'), "lambdas must be numeric")
-  # expect_error(iregnet(x, y, lambda=c(0.1, -0.3)), "lambdas must be positive and decreasing")
-  # expect_error(iregnet(x, y, lambda=c(0.1, 0.3)), "lambdas must be positive and decreasing")
+  expect_error(iregnet(x, y, lambda=c(0.1, -0.3)), "lambdas must be positive and decreasing.")
+  expect_error(iregnet(x, y, lambda=c(0.1, 0.3)), "lambdas must be positive and decreasing.")
 
   # misc
   expect_error(iregnet(x, y, alpha=-1), "alpha should be between 0 and 1")


### PR DESCRIPTION
Hey @anujkhare I have been testing your code on the `penalty.learning` data set.

Now with `standardize=TRUE` I do get a reasonable solution `beta` matrix. On the bright side, it yields lower validation error rates than the previous algorithm I was using (FISTA with squared hinge loss + L1). This is a very encouraging result!

Below: FISTA gets minimal validation error of about 18%.

![figure-fista-penalty-learning](https://cloud.githubusercontent.com/assets/932850/19698692/5865c5f4-9abe-11e6-8361-d7d83752602e.png)

Below: iregnet gets minimal valiadtion error of about 14%.

![figure-iregnet-penalty-learning](https://cloud.githubusercontent.com/assets/932850/19698723/7385985a-9abe-11e6-8969-a9b2beac1e44.png)

However I noticed that sometimes 1000 iterations are reached, so the `error_status` is not zero. That is unexpected, right? I added a test to make sure that `error_status` is 0 for this data set. Do you have any idea why it is taking so many iterations? One way to fix it would be to use different default thresholds. Do you think that is a good idea, or could you suggest another fix?

Also I tried to fit a model by first scaling the data myself, and then using `standardize=FALSE`. However, when I tried to scale the data by simply subtracting the mean and dividing by the standard deviation (divided by `n` not `n-1`), I was not able to get a solution that is consistent with `standardize=TRUE`. After looking through the C++ source code I found that https://github.com/anujkhare/iregnet/blob/90194b37746e7d0f0ea0e1b472c75f608c812f5e/src/iregnet_fit.cpp#L473 the `standardize_x` function only divides by the standard deviation (it does not first subtract the mean). If I use the same scaling in my test, I am able to get results that are consistent with `standardize=TRUE`. I think this is a bug, since usually we should always standardize the data by centering as well as scaling. Do you think this is easily fixable?
