### PR TITLE
return ggplot test fails

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,7 @@ exportPattern("^[[:alpha:]]+")
 useDynLib(iregnet)
 importFrom(Rcpp, sourceCpp)
 
-importFrom("ggplot2", "geom_line", "ggplot", "aes_string", "xlab", "ylab",
+importFrom("ggplot2", "geom_line", "ggplot", "aes", "xlab", "ylab",
            "labs")
 importFrom("methods", "cbind2")
 importFrom("utils", "head")

--- a/R/plot.iregnet.R
+++ b/R/plot.iregnet.R
@@ -54,5 +54,5 @@ plot.iregnet <- function(x, xvar=c("norm", "lambda"), label=TRUE, ...) {
 
   fig.iregnet.profile <- fig.iregnet.profile + ylab("Coefficients") +
                          labs(color="Variable name")
-  print(fig.iregnet.profile)
+  fig.iregnet.profile
 }

--- a/tests/testthat/test_plot.R
+++ b/tests/testthat/test_plot.R
@@ -1,0 +1,13 @@
+library(testthat)
+library(iregnet)
+context("\nplot")
+
+data(prostate,package="ElemStatLearn")
+pros <- subset(prostate,select=-train,train==TRUE)
+y.mat <- cbind(pros$lpsa, pros$lpsa)
+X.mat <- as.matrix(subset(pros, select=-lpsa))
+fit <- iregnet(X.mat, y.mat)
+gg <- plot(fit)
+test_that("plot method returns ggplot", {
+  expect_true(is.ggplot(gg))
+})

--- a/tests/testthat/test_plot.R
+++ b/tests/testthat/test_plot.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(iregnet)
+library(ggplot2)
 context("\nplot")
 
 data(prostate,package="ElemStatLearn")


### PR DESCRIPTION
it would be more user friendly if `plot.iregnet` returned a ggplot object, so then we could do things like `plot(fit)+xlim(0, 1)`

I added a test for returning a ggplot, which is currently failing
